### PR TITLE
Remove low() global function

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -234,7 +234,7 @@ class UploadBehavior extends ModelBehavior {
         $src = null;
         $createHandler = null;
         $outputHandler = null;
-        switch (low($pathinfo['extension'])) {
+        switch (strtolower($pathinfo['extension'])) {
         case 'gif':
             $createHandler = 'imagecreatefromgif';
             $outputHandler = 'imagegif';


### PR DESCRIPTION
replaced `low()` with `strtolower()` as `low()` was removed from CakePHP in v2.0. See http://book.cakephp.org/1.3/view/1134/low
