### PR TITLE
default_url issue

### DIFF
--- a/View/Helper/UploadHelper.php
+++ b/View/Helper/UploadHelper.php
@@ -47,7 +47,7 @@ class UploadHelper extends AppHelper {
             }
         }
 
-        if(isset($id) && isset($filename))
+        if(isset($id) && !empty($filename))
         {
             $settings = UploadBehavior::interpolate($model, $id, $field, $filename, $options['style'], array('webroot' => ''));
             $url = isset($settings['url']) ? $settings['url'] : $settings['path'];


### PR DESCRIPTION
$filename is set even when $data[$field.'_file_name'] or $data[$model][$field.'_file_name'] is empty! so you better use !empty in this situation. it took me a really long time to figure out why the helper ignores the 'default_url' when the _file_name-field  in the db is empty
