### PR TITLE
Fix to use "allowEmpty" option on validate

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -348,23 +348,27 @@ class UploadBehavior extends ModelBehavior {
         return false;
     }
 
-    public function attachmentMinSize(Model $model, $value, $min) {
+    public function attachmentMinSize(Model $model, $value, $min, $options = array()) {
         $value = array_shift($value);
         if (!empty($value['tmp_name'])) {
             return (int)$min <= (int)$value['size'];
+        } else if (isset($options['allowEmpty']) && $options['allowEmpty'] === false) {
+          return false;
         }
         return true;
     }
 
-    public function attachmentMaxSize(Model $model, $value, $max) {
+    public function attachmentMaxSize(Model $model, $value, $max, $options = array()) {
         $value = array_shift($value);
         if (!empty($value['tmp_name'])) {
             return (int)$value['size'] <= (int)$max;
+        } else if (isset($options['allowEmpty']) && $options['allowEmpty'] === false) {
+          return false;
         }
         return true;
     }
 
-    public function attachmentContentType(Model $model, $value, $contentTypes) {
+    public function attachmentContentType(Model $model, $value, $contentTypes, $options = array()) {
         $value = array_shift($value);
         if (!is_array($contentTypes)) {
             $contentTypes = array($contentTypes);
@@ -380,11 +384,13 @@ class UploadBehavior extends ModelBehavior {
                 }
             }
             return false;
+        } else if (isset($options['allowEmpty']) && $options['allowEmpty'] === false) {
+          return false;
         }
         return true;
     }
 
-    public function attachmentPresence(Model $model, $value) {
+    public function attachmentPresence(Model $model, $value, $options = array()) {
         $keys = array_keys($value);
         $field = $keys[0];
         $value = array_shift($value);
@@ -405,31 +411,32 @@ class UploadBehavior extends ModelBehavior {
         }
         return false;
     }
-    public function minWidth(Model $model, $value, $minWidth) {
-        return $this->_validateDimension($value, 'min', 'x', $minWidth);
+
+    public function minWidth(Model $model, $value, $minWidth, $options = array()) {
+        return $this->_validateDimension($value, 'min', 'x', $minWidth, $options);
     }
 
-    public function minHeight(Model $model, $value, $minHeight) {
-        return $this->_validateDimension($value, 'min', 'y', $minHeight);
+    public function minHeight(Model $model, $value, $minHeight, $options = array()) {
+        return $this->_validateDimension($value, 'min', 'y', $minHeight, $options);
     }
 
-    public function maxWidth(Model $model, $value, $maxWidth) {
+    public function maxWidth(Model $model, $value, $maxWidth, $options = array()) {
         $keys = array_keys($value);
         $field = $keys[0];
         $settings = self::$__settings[$model->name][$field];
-        if($settings['resizeToMaxWidth'] && !$this->_validateDimension($value, 'max', 'x', $maxWidth)) {
+        if($settings['resizeToMaxWidth'] && !$this->_validateDimension($value, 'max', 'x', $maxWidth, $options)) {
             $this->maxWidthSize = $maxWidth;
             return true;
         } else {
-            return $this->_validateDimension($value, 'max', 'x', $maxWidth);
+            return $this->_validateDimension($value, 'max', 'x', $maxWidth, $options);
         }
     }
 
-    public function maxHeight(Model $model, $value, $maxHeight) {
-        return $this->_validateDimension($value, 'max', 'y', $maxHeight);
+    public function maxHeight(Model $model, $value, $maxHeight, $options = array()) {
+        return $this->_validateDimension($value, 'max', 'y', $maxHeight, $options);
     }
 
-    private function _validateDimension($upload, $mode, $axis, $value) {
+    private function _validateDimension($upload, $mode, $axis, $value, $options) {
         $upload = array_shift($upload);
         $func = 'images'.$axis;
         if(!empty($upload['tmp_name'])) {
@@ -454,17 +461,21 @@ class UploadBehavior extends ModelBehavior {
                     break;
                 }
             }
+        } else if (isset($options['allowEmpty']) && $options['allowEmpty'] === true) {
+            return true;
         }
         return false;
     }
 
-    public function phpUploadError(Model $model, $value, $uploadErrors = array('UPLOAD_ERR_INI_SIZE', 'UPLOAD_ERR_FORM_SIZE', 'UPLOAD_ERR_PARTIAL', 'UPLOAD_ERR_NO_FILE', 'UPLOAD_ERR_NO_TMP_DIR', 'UPLOAD_ERR_CANT_WRITE', 'UPLOAD_ERR_EXTENSION')) {
+    public function phpUploadError(Model $model, $value, $uploadErrors = array('UPLOAD_ERR_INI_SIZE', 'UPLOAD_ERR_FORM_SIZE', 'UPLOAD_ERR_PARTIAL', 'UPLOAD_ERR_NO_FILE', 'UPLOAD_ERR_NO_TMP_DIR', 'UPLOAD_ERR_CANT_WRITE', 'UPLOAD_ERR_EXTENSION'), $options = array()) {
         $value = array_shift($value);
         if (!is_array($uploadErrors)) {
             $uploadErrors = array($uploadErrors);
         }
         if (!empty($value['error'])) {
             return !in_array($value['error'], $uploadErrors);
+        } else if (isset($options['allowEmpty']) && $options['allowEmpty'] === false) {
+            return false;
         }
         return true;
     }

--- a/README.textile
+++ b/README.textile
@@ -198,6 +198,20 @@ PHP: Error Messages Explained - Manual (http://www.php.net/manual/features.file-
 );
 </code></pre>
 
+Validate options:
+Validation function except "attachmentPresence" support the "allowEmpty" option.
+Return value if you do not specify "allowEmpty" option should be careful because different by validation function.
+
+The example below return true if there is no upload files or jpeg.
+<pre><code>var $validate = array(
+	'avatar' => array(
+		'rule' => array('attachmentContentType', 'image/jpeg'),
+		'message' => 'Only jpegs please',
+		'allowEmpty' => true
+	)
+);
+</code></pre>
+
 h4. You can change the path where the files are saved
 
 <pre><code>var $actsAs = array(


### PR DESCRIPTION
Validation function of cakephp option is passed at the end of the argument.

like: 
```
// Model/AppMode.php
$validates array(
    'avator' => array(
         'attachmentMinSize' => array(
            'rule' => array(minWidth, 1024),
            'message' => 'Please input file or the width of the image in more than 1024px',
            'allowEmpty' => true,
            'required' => false,
         )
    )
);

// Model/Behavior/UploadBehavior.php
// public function minWidth(Model $model, $value, $minWidth, $options = array()) {
var_dump($options);
array(6) {
  ["rule"]=>
  array(1) {
    [1]=>
    string(3) "1024"
  }
  ["required"]=>
  bool(false)
  ["allowEmpty"]=>
  bool(true)
  ["on"]=>
  NULL
  ["last"]=>
  bool(true)
  ["message"]=>
  string(70) "Please input file or the width of the image in more than 1024px"
}
```

The "allowEmpty" option I was corresponding to have been ignored in the case.
The return value for each validation function was different , but it was made as it is of the implementation with an emphasis on compatibility .