### PR TITLE
Changed the type attribute on the composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "szajbus/uploadpack",
     "description": "Easy way to handle file uploads in CakePHP",
     "version": "0.7.2",
-    "type": "library",
+    "type": "cakephp-plugin",
     "keywords": ["upload", "cakephp", "image processing"],
     "homepage": "https://github.com/szajbus/uploadpack",
     "license": "MIT",


### PR DESCRIPTION
When the type atribute on the composer.json file is cakephp-plugin, composer automatically places the plugin on the correct Plugin folder